### PR TITLE
Modify scripts to accept config values as command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@
 This repo provides a suite of tools for segmenting and extract clinical annotations from pathology data. 
 
 ## Installation
-
-To install the package, you can use pip. Navigate to the root directory of the repository and run:
-
-```bash
-pip install .
 ```
-This will install the package and its dependencies. Make sure you have a Python environment set up and activated before running the command.
+conda env create -f environment.yml
+```
+
+
+to create an environment called `radiology-report-segmentation` that you can activate via
+
+```
+conda activate radiology-report-segmentation
+```
 
 
 ## Function Descriptions

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: pathology-report-segmentation
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - git
+  - python=3.12
+  - pip
+  - pip:
+      - "git+https://github.com/clinical-data-mining/msk_cdm.git@dev#egg=msk_cdm"
+      - "git+https://github.com/clinical-data-mining/pathology_report_segmentation.git@dev#egg=pathology_report_segmentation"

--- a/pipeline/bash_run_python.sh
+++ b/pipeline/bash_run_python.sh
@@ -3,17 +3,23 @@
 set -e
 
 ROOT_PATH_PATHOLOGY_REPO=$1
-PATH_SCRIPT=$2
+CONDA_INSTALL_PATH=$2
+CONDA_ENV_NAME=$3
+MINIO_ENV=$4
+PATH_SCRIPT=$5
 
 test -n "$ROOT_PATH_PATHOLOGY_REPO"
+test -n "$CONDA_INSTALL_PATH"
+test -n "$CONDA_ENV_NAME"
+test -n "$MINIO_ENV"
 test -n "$PATH_SCRIPT"
 
 # Activate virtual env
 source $CONDA_INSTALL_PATH/etc/profile.d/conda.sh
-conda activate $CONDA_ENV
+conda activate $CONDA_ENV_NAME
 
 SCRIPT_FULL_PATH="$ROOT_PATH_PATHOLOGY_REPO/$PATH_SCRIPT"
 echo $SCRIPT_FULL_PATH
 
 # Run script
-python $SCRIPT_FULL_PATH
+python $SCRIPT_FULL_PATH --minio_env=$MINIO_ENV

--- a/pipeline/bash_run_python.sh
+++ b/pipeline/bash_run_python.sh
@@ -9,8 +9,8 @@ test -n "$ROOT_PATH_PATHOLOGY_REPO"
 test -n "$PATH_SCRIPT"
 
 # Activate virtual env
-source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
-conda activate conda-env-cdm
+source $CONDA_INSTALL_PATH/etc/profile.d/conda.sh
+conda activate $CONDA_ENV
 
 SCRIPT_FULL_PATH="$ROOT_PATH_PATHOLOGY_REPO/$PATH_SCRIPT"
 echo $SCRIPT_FULL_PATH

--- a/pipeline/cbioportal/cbio_gleason_summary.py
+++ b/pipeline/cbioportal/cbio_gleason_summary.py
@@ -1,4 +1,5 @@
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -7,7 +8,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as var
 
 FNAME_GLEASON = var.fname_path_gleason
 FNAME_MAP = var.fname_dop_anno
-FNAME_MINIO_ENV = var.minio_env
 FNAME_SAVE_PATIENT = var.fname_path_gleason_summary_patient
 FNAME_SAVE_SAMPLE = var.fname_path_gleason_summary_sample
 RENAME_SAMPLE = {'Gleason': 'GLEASON_SAMPLE_LEVEL'}
@@ -67,7 +67,7 @@ def create_gleason_summaries(
     fname_save_sample
 ):
     # Create minio object
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
     
     # Load data
     df_gleason, df_map = _load_data(
@@ -106,7 +106,16 @@ def create_gleason_summaries(
     return True
 
 def main():
-    fname_minio_env = FNAME_MINIO_ENV
+    parser = argparse.ArgumentParser(description="cbio_gleason_summary.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
+    fname_minio_env = args.minio_env
     fname_gleason = FNAME_GLEASON
     fname_map = FNAME_MAP
     fname_save_patient = FNAME_SAVE_PATIENT

--- a/pipeline/cbioportal/cbio_mmr_summary.py
+++ b/pipeline/cbioportal/cbio_mmr_summary.py
@@ -1,4 +1,5 @@
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -7,7 +8,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as var
 
 FNAME_MMR = 'pathology/table_timeline_mmr_calls.tsv'
 FNAME_SAVE_PATIENT = 'pathology/table_summary_mmr_patient.tsv'
-FNAME_MINIO_ENV = var.minio_env
 
 
 def _load_data(
@@ -63,7 +63,16 @@ def create_dmmr_summary(
     return df_mmr_p
 
 def main():
-    fname_minio_env = FNAME_MINIO_ENV
+    parser = argparse.ArgumentParser(description="cbio_mmr_summary.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
+    fname_minio_env = args.minio_env
     fname_mmr = FNAME_MMR
     fname_save_patient = FNAME_SAVE_PATIENT
 

--- a/pipeline/cbioportal/cbio_pdl1_summary.py
+++ b/pipeline/cbioportal/cbio_pdl1_summary.py
@@ -1,4 +1,5 @@
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -7,7 +8,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as var
 
 FNAME_PDL1 = var.fname_path_pdl1
 FNAME_MAP = var.fname_dop_anno
-FNAME_MINIO_ENV = var.minio_env
 FNAME_SAVE_PATIENT = var.fname_path_pdl1_summary_patient
 FNAME_SAVE_SAMPLE = var.fname_path_pdl1_summary_sample
 
@@ -65,7 +65,7 @@ def create_pdl1_summaries(
     fname_save_sample
 ):
     # Create minio object
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
     
     # Load data
     df_pdl1, df_map = _load_data(
@@ -104,7 +104,16 @@ def create_pdl1_summaries(
     return True
 
 def main():
-    fname_minio_env = FNAME_MINIO_ENV
+    parser = argparse.ArgumentParser(description="cbio_pdl1_summary.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
+    fname_minio_env = args.minio_env
     fname_pdl1 = FNAME_PDL1
     fname_map = FNAME_MAP
     fname_save_patient = FNAME_SAVE_PATIENT

--- a/pipeline/cbioportal/cbio_timeline_gleason.py
+++ b/pipeline/cbioportal/cbio_timeline_gleason.py
@@ -3,6 +3,7 @@ cbio_timeline_gleason.py
 
 """
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -12,7 +13,6 @@ from msk_cdm.data_processing import convert_to_int
 
 fname_gleason = config_cdm.fname_path_gleason
 fname_timeline_gleason = config_cdm.fname_path_gleason_cbio_timeline
-fname_minio_env = config_cdm.minio_env
 _col_order_gleason = [
     'MRN', 
     'START_DATE', 
@@ -25,8 +25,16 @@ _col_order_gleason = [
 
     
 def main():
+    parser = argparse.ArgumentParser(description="cbio_timeline_gleason.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
     
-    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
+    obj_minio = MinioAPI(fname_minio_env=args.minio_env)
 
     obj = obj_minio.load_obj(path_object=fname_gleason)
     df_gleason = pd.read_csv(obj, sep='\t')

--- a/pipeline/cbioportal/cbio_timeline_mmr.py
+++ b/pipeline/cbioportal/cbio_timeline_mmr.py
@@ -5,6 +5,7 @@ cbio_timeline_mmr.py
 
 """
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -13,7 +14,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as config_cdm
 
 fname_mmr = config_cdm.fname_path_mmr
 fname_timeline_mmr = "pathology/table_timeline_mmr_calls.tsv"
-fname_minio_env = config_cdm.minio_env
 _col_order_mmr = [
     'MRN',
     'START_DATE',
@@ -26,8 +26,16 @@ _col_order_mmr = [
 
 
 def main():
+    parser = argparse.ArgumentParser(description="cbio_timeline_mmr.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
-    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
+    obj_minio = MinioAPI(fname_minio_env=args.minio_env)
 
     obj = obj_minio.load_obj(path_object=fname_mmr)
     df_mmr = pd.read_csv(obj, sep='\t')

--- a/pipeline/cbioportal/cbio_timeline_pdl1.py
+++ b/pipeline/cbioportal/cbio_timeline_pdl1.py
@@ -1,10 +1,8 @@
 """"
 cbio_timeline_pdl1.py
-
-
-
 """
 #Import the requisite library
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -13,7 +11,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as config_cdm
 
 fname_pdl1 = config_cdm.fname_path_pdl1
 fname_timeline_pdl1 = config_cdm.fname_path_pdl1_cbio_timeline
-fname_minio_env = config_cdm.minio_env
 _col_order_pdl1 = [
     'MRN', 
     'START_DATE', 
@@ -26,8 +23,16 @@ _col_order_pdl1 = [
 
     
 def main():
+    parser = argparse.ArgumentParser(description="cbio_timeline_pdl1.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
     
-    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
+    obj_minio = MinioAPI(fname_minio_env=args.minio_env)
 
     obj = obj_minio.load_obj(path_object=fname_pdl1)
     df_pdl1 = pd.read_csv(obj, sep='\t')

--- a/pipeline/cbioportal/cbio_timeline_sequencing.py
+++ b/pipeline/cbioportal/cbio_timeline_sequencing.py
@@ -3,13 +3,13 @@ cbio_timeline_sequencing.py
 
 Generates cBioPortal timeline files for sequencing dates
 """
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as config_cdm
 
 
-FNAME_MINIO_ENV = config_cdm.minio_env
 FNAME_PATHOLOGY = config_cdm.fname_path_clean
 FNAME_SAVE_TIMELINE_SEQ = config_cdm.fname_path_sequencing_cbio_timeline
 COL_DTE_SEQ = 'DTE_TUMOR_SEQUENCING'
@@ -28,8 +28,8 @@ COL_ORDER_SEQ = [
 ]
 
 
-def sequencing_timeline():
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+def sequencing_timeline(fname_minio_env):
+    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
     
     print('Loading %s' % FNAME_PATHOLOGY)
     obj = obj_minio.load_obj(path_object=FNAME_PATHOLOGY)
@@ -68,17 +68,22 @@ def sequencing_timeline():
         path_object=FNAME_SAVE_TIMELINE_SEQ,
         sep='\t'
     )
-        
 
     return df_samples_seq_f
 
 def main():
+    parser = argparse.ArgumentParser(description="cbio_timeline_sequencing.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
-    df_seq_timeline = sequencing_timeline()
+    df_seq_timeline = sequencing_timeline(fname_minio_env=args.minio_env)
     print(df_seq_timeline.sample())
     
 
 if __name__ == '__main__':
     main()
-    
-    

--- a/pipeline/cbioportal/cbio_timeline_specimen.py
+++ b/pipeline/cbioportal/cbio_timeline_specimen.py
@@ -3,6 +3,7 @@ cbioportal_timeline_specimen.py
 
 Generates cBioPortal timeline files for date of surgery for corresponding sequenced samples
 """
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -10,7 +11,6 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as config_cdm
 from msk_cdm.data_processing import convert_to_int
 
 
-FNAME_MINIO_ENV = config_cdm.minio_env
 FNAME_IMPACT_SUMMARY_SAMPLE = config_cdm.fname_path_summary
 FNAME_SAVE_TIMELINE_SPEC = config_cdm.fname_path_specimen_surgery_cbio_timeline
 COL_ORDER_SEQ = [
@@ -23,8 +23,8 @@ COL_ORDER_SEQ = [
 ]
 
 
-def sample_acquisition_timeline():
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+def sample_acquisition_timeline(fname_minio_env):
+    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
     ### Load Dx timeline data
     col_use = [
         'MRN', 
@@ -64,8 +64,16 @@ def sample_acquisition_timeline():
     return df_samples_seq_f
 
 def main():
+    parser = argparse.ArgumentParser(description="cbioportal_timeline_specimen.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
-    df_seq_timeline = sample_acquisition_timeline()
+    df_seq_timeline = sample_acquisition_timeline(fname_minio_env=args.minio_env)
     print(df_seq_timeline.sample())
     
 

--- a/pipeline/cbioportal/specimen_cbioportal_timeline.py
+++ b/pipeline/cbioportal/specimen_cbioportal_timeline.py
@@ -1,8 +1,7 @@
 """"
 specimen_cbioportal_timeline.py
-
-
 """
+import argparse
 import pandas as pd
 import numpy as np
 from msk_cdm.minio import MinioAPI
@@ -161,16 +160,29 @@ class cBioPortalSpecimenInfo(object):
  
 
 def main():
+    parser = argparse.ArgumentParser(description="specimen_cbioportal_timeline.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    parser.add_argument(
+        "--sample_file",
+        dest="sample_file",
+        required=True,
+        help="location of clinical sample data file",
+    )
+    args = parser.parse_args()
 
-    fname_sid = config_cdm.fname_cbio_sid
     fname_summary = config_cdm.fname_impact_summary_sample
     fname_demo = config_cdm.fname_demo
     fname_save_timeline_seq = config_cdm.fname_save_spec_timeline
     fname_save_timeline_spec = config_cdm.fname_save_spec_surg_timeline
 
     obj_dx_timeline = cBioPortalSpecimenInfo(
-        fname_minio_config=config_cdm.minio_env,
-        fname_impact_sid=fname_sid,
+        fname_minio_config=args.minio_env,
+        fname_impact_sid=args.sample_file,
         fname_impact_summary=fname_summary,
         fname_demo=fname_demo,
         fname_save_seq=fname_save_timeline_seq,

--- a/pipeline/transformations/pipeline_accession_extraction.py
+++ b/pipeline/transformations/pipeline_accession_extraction.py
@@ -1,6 +1,6 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import PathologyExtractAccession
-
 
 ## Constants
 col_label_access_num = 'ACCESSION_NUMBER'
@@ -9,10 +9,18 @@ col_spec_sub = 'SPECIMEN_SUBMITTED'
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_accession_extraction.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     # Extract source accession number
     obj_p = PathologyExtractAccession(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname=c_dar.fname_darwin_path_col_spec_sub,
         col_label_access_num=col_label_access_num,
         col_label_spec_num=col_label_spec_num,

--- a/pipeline/transformations/pipeline_clean_pathology.py
+++ b/pipeline/transformations/pipeline_clean_pathology.py
@@ -1,10 +1,19 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.segmentation import InitCleanPathology
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_clean_pathology.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     obj_path = InitCleanPathology(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname=c_dar.fname_pathology,
         fname_save=c_dar.fname_path_clean
     )

--- a/pipeline/transformations/pipeline_dop_extraction.py
+++ b/pipeline/transformations/pipeline_dop_extraction.py
@@ -1,3 +1,4 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import PathologyExtractDOP
 
@@ -8,9 +9,18 @@ col_spec_sub = 'SPECIMEN_SUBMITTED'
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_dop_extraction.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
     # Extract DOP
     obj_p = PathologyExtractDOP(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname=c_dar.fname_darwin_path_col_spec_sub,
         col_label_access_num=col_label_access_num,
         col_label_spec_num=col_label_spec_num,

--- a/pipeline/transformations/pipeline_dop_wrapper.py
+++ b/pipeline/transformations/pipeline_dop_wrapper.py
@@ -1,11 +1,21 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import CombineAccessionDOPImpact
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_dop_wrapper.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
     # Extract source accession number
     obj_p = CombineAccessionDOPImpact(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_accession=c_dar.fname_path_accessions,
         fname_dop=c_dar.fname_spec_part_dop,
         fname_path=c_dar.fname_path_clean,

--- a/pipeline/transformations/pipeline_gleason_extraction.py
+++ b/pipeline/transformations/pipeline_gleason_extraction.py
@@ -1,3 +1,4 @@
+import argparse
 import numpy as np
 import pandas as pd
 
@@ -9,13 +10,20 @@ from pathology_report_segmentation.annotations import extractGleason
 ## Constants
 FNAME_SAVE = c_dar.fname_path_gleason
 FNAME_PATH = c_dar.fname_pathology
-FNAME_MINIO_ENV = c_dar.minio_env
 COLS_SAVE = ['MRN','Accession Number','Path Procedure Date','Gleason']
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_gleason_extraction.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     print('Loading %s' % FNAME_PATH)
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+    obj_minio = MinioAPI(fname_minio_env=args.minio_env)
     obj = obj_minio.load_obj(path_object=FNAME_PATH)
     df_path = pd.read_csv(obj, sep='\t', low_memory=False)
 

--- a/pipeline/transformations/pipeline_id_mapping.py
+++ b/pipeline/transformations/pipeline_id_mapping.py
@@ -1,10 +1,20 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import create_id_mapping_pathology
+
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_id_mapping.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     # Extract DOP
     df_mapping = create_id_mapping_pathology(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_path=c_dar.fname_path_clean,
         fname_out_mapping=c_dar.fname_id_map
     )

--- a/pipeline/transformations/pipeline_impact_annotation_combiner.py
+++ b/pipeline/transformations/pipeline_impact_annotation_combiner.py
@@ -1,11 +1,20 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import PathologyImpactDOPAnno
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_impact_annotation_combiner.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     objd = PathologyImpactDOPAnno(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_path_summary=c_dar.fname_combine_dop_accession,
         fname_surgery=c_dar.fname_surg,
         fname_ir=c_dar.fname_ir,

--- a/pipeline/transformations/pipeline_mmr_extraction.py
+++ b/pipeline/transformations/pipeline_mmr_extraction.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 
 from pathology_report_segmentation.annotations import extractMMR
@@ -8,9 +9,17 @@ from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 ## Constants
 FNAME_SAVE = c_dar.fname_path_mmr
 FNAME_PATH = c_dar.fname_pathology
-FNAME_MINIO_ENV = c_dar.minio_env
 
-obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+parser = argparse.ArgumentParser(description="pipeline_mmr_extraction.py")
+parser.add_argument(
+    "--minio_env",
+    dest="minio_env",
+    required=True,
+    help="location of Minio environment file",
+)
+args = parser.parse_args()
+
+obj_minio = MinioAPI(fname_minio_env=args.minio_env)
 obj = obj_minio.load_obj(path_object=FNAME_PATH)
 df_path = pd.read_csv(obj, sep='\t', low_memory=False)
 

--- a/pipeline/transformations/pipeline_parse_molecular_reports.py
+++ b/pipeline/transformations/pipeline_parse_molecular_reports.py
@@ -1,10 +1,20 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.segmentation import ParseMolecularPathology
 
 def main():
 
+    parser = argparse.ArgumentParser(description="pipeline_parse_molecular_reports.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
     obj_m = ParseMolecularPathology(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_path_clean=c_dar.fname_path_clean,
         fname_save=c_dar.fname_darwin_path_molecular
     )

--- a/pipeline/transformations/pipeline_parse_specimen_submitted.py
+++ b/pipeline/transformations/pipeline_parse_specimen_submitted.py
@@ -1,11 +1,20 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.segmentation import PathologyParseSpecSubmitted
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_parse_specimen_submitted.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     obj_mol = PathologyParseSpecSubmitted(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_path_parsed=c_dar.fname_path_clean,
         col_spec_sub='SPECIMEN_SUBMISSION_LIST',
         list_cols_id=['MRN', 'ACCESSION_NUMBER'],

--- a/pipeline/transformations/pipeline_parse_surgical_reports.py
+++ b/pipeline/transformations/pipeline_parse_surgical_reports.py
@@ -1,10 +1,19 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.segmentation import ParseSurgicalPathology
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_parse_surgical_reports.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     obj_s = ParseSurgicalPathology(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_path_clean=c_dar.fname_path_clean,
         fname_save=c_dar.fname_darwin_path_surgical
     )

--- a/pipeline/transformations/pipeline_parse_surgical_specimens.py
+++ b/pipeline/transformations/pipeline_parse_surgical_specimens.py
@@ -1,11 +1,21 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 
 from pathology_report_segmentation.segmentation import ParseSurgicalPathologySpecimens
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_parse_surgical_specimens.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
     obj_parse = ParseSurgicalPathologySpecimens(
-        fname_minio_env=c_dar.minio_env,
+        fname_minio_env=args.minio_env,
         fname_darwin_pathology_parsed=c_dar.fname_darwin_path_surgical,
         fname_save=c_dar.fname_darwin_path_clean_parsed_specimen
     )

--- a/pipeline/transformations/pipeline_pdl1_extraction.py
+++ b/pipeline/transformations/pipeline_pdl1_extraction.py
@@ -1,13 +1,23 @@
+import argparse
 from msk_cdm.data_classes.legacy import CDMProcessingVariables as c_dar
 from pathology_report_segmentation.annotations import PathologyExtractPDL1
 
 
 def main():
+    parser = argparse.ArgumentParser(description="pipeline_pdl1_extraction.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
+
     ## Constants
     col_text = 'PATH_REPORT_NOTE'
     fname_save = c_dar.fname_path_pdl1
     fname_path = c_dar.fname_path_clean
-    fname_minio_env = c_dar.minio_env
+    fname_minio_env = args.minio_env
 
     # Extract PD-L1
     obj_p = PathologyExtractPDL1(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,25 +10,23 @@ include = ["pathology_report_segmentation*"]
 name = "pathology_report_segmentation"
 version = "0.1.0"
 
-requires-python = ">=3.9, <3.11"
+requires-python = ">=3.9, <4"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = [
-    "msk_cdm @ git+https://github.com/clinical-data-mining/msk_cdm.git",
+#dependencies = [
+#    "msk_cdm @ git+https://github.com/clinical-data-mining/msk_cdm.git",
+#
+#    # requirements for philter that aren't transitively included in their install:
+#    "numpy>=1.19.0",
+#    "pandas>=1.0.5",
+#
+#]
 
-    # requirements for philter that aren't transitively included in their install:
-    "numpy>=1.19.0",
-    "pandas>=1.0.5",
 
-]
-
-[project.optional-dependencies]
-dev = ["check-manifest"]
-test =["pytest", "tox"]
 
 [tool.setuptools_scm]
 root = "."

--- a/src/pathology_report_segmentation/annotations/pathology_parse_heme_section_bm_biopsy.py
+++ b/src/pathology_report_segmentation/annotations/pathology_parse_heme_section_bm_biopsy.py
@@ -2,6 +2,7 @@
     pathology_parse_heme_section_bm_biopsy.py
 
 """
+import argparse
 import pandas as pd
 
 from msk_cdm.minio import MinioAPI
@@ -139,8 +140,16 @@ class ParseHemePathologySectionBMBx(object):
         return df
 
 def main():
+    parser = argparse.ArgumentParser(description="pathology_parse_heme_section_bm_biopsy.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
-    obj_s = ParseHemePathologySectionBMBx(fname_minio_env=c_dar.minio_env,
+    obj_s = ParseHemePathologySectionBMBx(fname_minio_env=args.minio_env,
                                        fname_path_heme=c_dar.fname_darwin_path_heme,
                                        fname_save=c_dar.fname_darwin_path_heme_parse_bm_biopsy)
     df = obj_s.return_output()

--- a/src/pathology_report_segmentation/annotations/pathology_parse_heme_section_periph_blood.py
+++ b/src/pathology_report_segmentation/annotations/pathology_parse_heme_section_periph_blood.py
@@ -5,6 +5,7 @@
 
 
 """
+import argparse
 import os
 import sys  
 sys.path.insert(0,  os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', '..', 'cdm-utilities')))
@@ -162,9 +163,17 @@ def main():
     from data_classes_cdm import CDMProcessingVariables as c_dar
     from utils import set_debug_console
 
+    parser = argparse.ArgumentParser(description="pathology_parse_heme_section_periph_blood.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     set_debug_console()
-    obj_s = ParseHemePathologySectionPeriphBlood(fname_minio_env=c_dar.minio_env,
+    obj_s = ParseHemePathologySectionPeriphBlood(fname_minio_env=args.minio_env,
                                    fname_path_heme=c_dar.fname_darwin_path_heme,
                                    fname_save=c_dar.fname_darwin_path_heme_parse_periph_blood)
     df = obj_s.return_output()

--- a/src/pathology_report_segmentation/annotations/pathology_synoptic_logistic_model.py
+++ b/src/pathology_report_segmentation/annotations/pathology_synoptic_logistic_model.py
@@ -5,6 +5,7 @@
 
 
 """
+import argparse
 import os
 import sys 
 sys.path.insert(0,  os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', '..', 'cdm-utilities')))
@@ -165,12 +166,20 @@ def main():
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'cdm-utilities')))
     from data_classes_cdm import CDMProcessingVariables as c_dar
     
+    parser = argparse.ArgumentParser(description="pathology_synoptic_logistic_model.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
 
     fname_save = c_dar.fname_path_synoptic
     fname = c_dar.fname_darwin_path_clean_parsed_specimen
     fname_labels = c_dar.fname_path_synoptic_labels
 
-    obj_syn = SynopticReportClassifier(fname_minio_env=c_dar.minio_env,
+    obj_syn = SynopticReportClassifier(fname_minio_env=args.minio_env,
                                        fname_parsed_spec=fname,   
                                        fname_synoptic_labels=fname_labels,
                                        fname_save=fname_save)

--- a/src/pathology_report_segmentation/segmentation/pathology_parse_heme.py
+++ b/src/pathology_report_segmentation/segmentation/pathology_parse_heme.py
@@ -23,6 +23,7 @@
     THE SLIDES (AND/OR OTHER MATERIAL), AND THAT I HAVE REVIEWED AND APPROVED
     THIS REPORT.
 """
+import argparse
 import os
 import sys  
 sys.path.insert(0,  os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', '..', 'cdm-utilities')))
@@ -336,8 +337,16 @@ def main():
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'cdm-utilities')))
     from data_classes_cdm import CDMProcessingVariables as c_dar
 
+    parser = argparse.ArgumentParser(description="pathology_parse_heme.py")
+    parser.add_argument(
+        "--minio_env",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    args = parser.parse_args()
     
-    obj_s = ParseHemePathology(fname_minio_env=c_dar.minio_env,
+    obj_s = ParseHemePathology(fname_minio_env=args.minio_env,
                                fname_path_clean=c_dar.fname_path_clean,
                                fname_save=c_dar.fname_darwin_path_heme)
     df = obj_s.return_df()


### PR DESCRIPTION
This PR modifies all Python and Bash scripts called by the CDM DAGs to accept command-line arguments for environment-specific configuration values (minio environment, databricks environment, conda install path, conda environment, script/repo paths). This will enable a cleaner split when running development and production code.